### PR TITLE
create one search entry, not multiple

### DIFF
--- a/update-resolv-conf.sh
+++ b/update-resolv-conf.sh
@@ -45,10 +45,15 @@ up)
     fi
   done
   R=""
-  for DS in $IF_DNS_SEARCH ; do
-    R="${R}search $DS
+  if [ "$IF_DNS_SEARCH" ]; then
+    R="search "
+    for DS in $IF_DNS_SEARCH ; do
+      R="${R} $DS"
+    done
+  R="${R}
 "
-  done
+  fi
+
   for NS in $IF_DNS_NAMESERVERS ; do
     R="${R}nameserver $NS
 "


### PR DESCRIPTION
The current way just uses the last domain entry.
The new way combines all submitted domains/search suffixes into one line, which makes things work correctly.

Before:
search last.suffix

After:
search first.suffix next.suffix last.suffix

Signed-off-by: Nico Schottelius nico@bento.schottelius.org
