### PR TITLE
Add alternative usage to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ down /etc/openvpn/update-resolv-conf.sh
 
 Just start your openvpn client with the command you used to do.
 
+Alternatively, if you don't want to edit your client configuration, you can add the following options to your openvpn command:
+```
+--script-security 2 --up /etc/openvpn/update-resolv-conf.sh --down /etc/openvpn/update-resolv-conf.sh
+```
+
 ### Support
 
 For bugs and another questions open a ticket in the [Isssues Page](https://github.com/masterkorp/openvpn-update-resolv-conf/issues).


### PR DESCRIPTION
I'm currently working in an environment where the openvpn client config file is provided to us and regularly updated with new keys. It's a pain to edit the file each time they update it so I was looking for a way to do the same thing from the command line which I can put in a wrapper script.