### PR TITLE
Added exclusive flag to resolvconf

### DIFF
--- a/update-resolv-conf.sh
+++ b/update-resolv-conf.sh
@@ -52,8 +52,8 @@ up)
     R="${R}nameserver $NS
 "
   done
-  #echo -n "$R" | $RESOLVCONF -p -a "${dev}"
-  echo -n "$R" | $RESOLVCONF -a "${dev}.inet"
+  #echo -n "$R" | $RESOLVCONF -x -p -a "${dev}"
+  echo -n "$R" | $RESOLVCONF -x -a "${dev}.inet"
   ;;
 down)
   $RESOLVCONF -d "${dev}.inet"


### PR DESCRIPTION
This makes the vpn interface exclusive in resolvconf to stop the old, non-vpn nameservers appearing in /etc/resolv.conf. Without it the old nameserver remains and occasionally takes precedence, leading to DNS leaks.