### PR TITLE
Workaround to force exit with no errors. Due to an apparent conflict …

### DIFF
--- a/update-resolv-conf.sh
+++ b/update-resolv-conf.sh
@@ -59,3 +59,9 @@ down)
   $RESOLVCONF -d "${dev}.inet"
   ;;
 esac
+
+# Workaround / jm@epiclabs.io 
+# force exit with no errors. Due to an apparent conflict with the Network Manager
+# $RESOLVCONF sometimes exits with error code 6 even though it has performed the
+# action correctly and OpenVPN shuts down.
+exit 0


### PR DESCRIPTION
…with the Network Manager, $RESOLVCONF sometimes exits with error code 6 even though it has performed the action correctly and OpenVPN shuts down.