### PR TITLE
Changed from using 'which` to `type -p`

### DIFF
--- a/update-resolv-conf.sh
+++ b/update-resolv-conf.sh
@@ -18,7 +18,7 @@
 # foreign_option_4='dhcp-option DOMAIN-SEARCH bnc.local'
 
 ## You might need to set the path manually here, i.e.
-RESOLVCONF=$(which resolvconf)
+RESOLVCONF=$(type -p resolvconf)
 
 case $script_type in
 


### PR DESCRIPTION
There are plenty of issues posted in the Arch Wiki forums about this. `which resolvconf` works when run from commandline but not when this scripted is called by openvpn. `type -p resolvconf` works in both cases.