### PR TITLE
Compatible with openvpn down-root plugin.

### DIFF
--- a/update-resolv-conf.sh
+++ b/update-resolv-conf.sh
@@ -59,7 +59,7 @@ up)
   #echo -n "$R" | $RESOLVCONF -x -p -a "${dev}"
   echo -n "$R" | $RESOLVCONF -x -a "${dev}.inet"
   ;;
-down)
+*)
   $RESOLVCONF -d "${dev}.inet"
   ;;
 esac


### PR DESCRIPTION
 - When openvpn calls a script with 'down' directive, the process itself has already been
   running as non-root user, so that the script called by 'down' directive will be executed
   in insufficient priveledge. This leads to failure of restore the resolv.conf file.

   In this case, we can use the 'down-root' plugin of openvpn to solve this issue. However we
   need a slight modification in the update-resolv-conf.sh script due to lacking 'script_type'
   env variable when openvpn plugin calls the script.